### PR TITLE
Fix resource and QC output tracking

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -13,5 +13,6 @@
     },
     "metadata":"test/Mycolicibacterium_smegmatis/deseq_metadata.csv",
     "run_gunc":"true",
+    "run_sortmerna":"false",
     "quantification_tool":"star"
 }

--- a/config/tools.json
+++ b/config/tools.json
@@ -21,6 +21,12 @@
     "multiqc": {
         "mem": 1024
     },
+    "strandedness_check": {
+        "enabled": "true",
+        "mode": "warn",
+        "min_fraction": 0.75,
+        "min_ratio": 2.0
+    },
     "trim_galore": {
         "mem": 1024
     },

--- a/config/tools.json
+++ b/config/tools.json
@@ -24,6 +24,12 @@
     "trim_galore": {
         "mem": 1024
     },
+    "sortmerna": {
+        "mem": 4096,
+        "threads": 8,
+        "refs": [],
+        "extra": ""
+    },
     "combine_quants": {
         "mem": 1024
     },

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -85,3 +85,7 @@ rule all:
             rules.qc_summary.output[0],
             project=pep.sample_table.project.unique().tolist(),
         ),
+        expand(
+            rules.multiqc.output.html,
+            project=pep.sample_table.project.unique().tolist(),
+        ),

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -85,6 +85,15 @@ rule all:
             rules.qc_summary.output[0],
             project=pep.sample_table.project.unique().tolist(),
         ),
+        (
+            expand(
+                rules.strandedness_summary.output[0],
+                project=pep.sample_table.project.unique().tolist(),
+            )
+            if config_flag(config.get("strandedness_check", {}), "enabled", "true")
+            and config["quantification_tool"].lower() in ["star", "featurecounts"]
+            else []
+        ),
         expand(
             rules.multiqc.output.html,
             project=pep.sample_table.project.unique().tolist(),

--- a/workflow/documentation.md
+++ b/workflow/documentation.md
@@ -11,8 +11,8 @@ inside `workflow/`.
 - `rules/resources.smk`: prepares reference resources, Kallisto indices, STAR
   indices, and optional GUNC databases.
 - `rules/trimming.smk`: trims paired-end and single-end reads with Trim Galore.
-- `rules/metrics.smk`: runs FastQC, FastQ Screen, GUNC, MultiQC, and the final
-  per-sample QC summary.
+- `rules/metrics.smk`: runs FastQC, FastQ Screen, GUNC, strandedness checks,
+  MultiQC, and the final per-sample QC summary.
 - `rules/quantification.smk`: runs Kallisto, STAR, or FeatureCounts
   quantification and merges per-sample outputs.
 - `rules/deseq.smk`: runs DESeq2 and writes differential-expression tables plus
@@ -24,6 +24,11 @@ inside `workflow/`.
   and project-level rule inputs.
 - `scripts/combine_star_counts.py`: merges STAR `ReadsPerGene.out.tab` files.
   The `--strandedness` option selects the STAR count column.
+- `scripts/check_strandedness.py`: infers library strandedness from STAR
+  `ReadsPerGene.out.tab` columns and compares it to the configured STAR or
+  FeatureCounts strandedness setting.
+- `scripts/merge_strandedness_reports.py`: merges per-sample strandedness
+  reports into the final project-level QC table.
 - `scripts/combine_featurecounts.py`: merges per-sample FeatureCounts outputs.
 - `scripts/combine_kallisto.py`: merges Kallisto `abundance.tsv` files from
   paired-end and single-end output directories.
@@ -42,6 +47,7 @@ inside `workflow/`.
 
 - `results/{project}/final/multiqc/multiqc_report.html`
 - `results/{project}/final/qc/{project}_sample_qc_summary.tsv`
+- `results/{project}/final/qc/{project}_strandedness_summary.tsv`
 - `results/{project}/count_annotation_overlap/{project}_count_annotation_overlap.tsv`
 - `results/{project}/gene_biotype_count_summary/{project}_gene_biotype_count_summary.tsv`
 - `results/{project}/final/quantification/star/gene_counts_all_samples.tsv`
@@ -65,6 +71,16 @@ inside `workflow/`.
 - `results/{project}/pca/{project}_pca.svg`
 - `results/{project}/library_sizes_size_factors/{project}_library_sizes_size_factors.png`
 - `results/{project}/library_sizes_size_factors/{project}_library_sizes_size_factors.svg`
+
+## Strandedness Checks
+
+`strandedness_check.enabled` controls whether STAR/FeatureCounts workflows infer
+library strandedness from STAR `ReadsPerGene.out.tab` outputs. The checker
+compares the inferred value to `star.gene_counts_strandedness` for STAR
+quantification or `featurecounts.strandedness` for FeatureCounts quantification.
+Set `strandedness_check.mode` to `warn` to write mismatch reports without
+failing the workflow, or `fail` to stop when inferred strandedness conflicts
+with the configured count mode.
 
 ## Development Checks
 

--- a/workflow/envs/trimming.yml
+++ b/workflow/envs/trimming.yml
@@ -4,3 +4,4 @@ channels:
   - conda-forge
 dependencies:
   - trim-galore=2.2.0
+  - sortmerna=4.3.7

--- a/workflow/rules/metrics.smk
+++ b/workflow/rules/metrics.smk
@@ -200,6 +200,14 @@ def get_multiqc_subsamples(wildcards):
                         project=project, subsample=subsample
                     )
                 )
+                if config_flag(
+                    config.get("strandedness_check", {}), "enabled", "true"
+                ):
+                    metricsLST.append(
+                        rules.strandedness_check.output[0].format(
+                            project=project, subsample=subsample
+                        )
+                    )
             elif seq_method == "single_end":
                 metricsLST.append(
                     rules.star_reads_per_gene_single.output.counts.format(
@@ -221,6 +229,14 @@ def get_multiqc_subsamples(wildcards):
                         project=project, subsample=subsample
                     )
                 )
+                if config_flag(
+                    config.get("strandedness_check", {}), "enabled", "true"
+                ):
+                    metricsLST.append(
+                        rules.strandedness_check_single.output[0].format(
+                            project=project, subsample=subsample
+                        )
+                    )
         elif config["quantification_tool"].lower() == "featurecounts":
             if seq_method == "paired_end":
                 metricsLST.append(
@@ -233,6 +249,14 @@ def get_multiqc_subsamples(wildcards):
                         project=project, subsample=subsample
                     )
                 )
+                if config_flag(
+                    config.get("strandedness_check", {}), "enabled", "true"
+                ):
+                    metricsLST.append(
+                        rules.strandedness_check.output[0].format(
+                            project=project, subsample=subsample
+                        )
+                    )
             elif seq_method == "single_end":
                 metricsLST.append(
                     rules.featurecounts_single.output.summary.format(
@@ -244,6 +268,14 @@ def get_multiqc_subsamples(wildcards):
                         project=project, subsample=subsample
                     )
                 )
+                if config_flag(
+                    config.get("strandedness_check", {}), "enabled", "true"
+                ):
+                    metricsLST.append(
+                        rules.strandedness_check_single.output[0].format(
+                            project=project, subsample=subsample
+                        )
+                    )
         if config["run_gunc"].lower() == "true":
             metricsLST.append(
                 rules.gunc_plot.output[0].format(project=project, subsample=subsample)
@@ -471,6 +503,102 @@ rule qc_summary:
     shell:
         """
         python3 workflow/scripts/summarize_qc.py --metadata {input.metadata} --counts {input.counts} --output {output} --fastqc {input.fastqc} --fastq-screen {input.fastq_screen} --star-logs {input.star_logs} 2> {log}
+        """
+
+
+rule strandedness_check:
+    input:
+        counts=rules.star_reads_per_gene.output.counts,
+    output:
+        "results/{project}/reports/strandedness_paired/{subsample}.strandedness.tsv",
+    log:
+        "logs/{project}/reports/strandedness/{subsample}.log",
+    conda:
+        "../envs/metrics.yml"
+    resources:
+        mem_mb=config["multiqc"]["mem"],
+    params:
+        sample="{subsample}",
+        quantification_tool=config["quantification_tool"],
+        star_strandedness=config["star"].get(
+            "gene_counts_strandedness", "unstranded"
+        ),
+        featurecounts_strandedness=config["featurecounts"].get("strandedness", 0),
+        mode=config["strandedness_check"].get("mode", "warn"),
+        min_fraction=config["strandedness_check"].get("min_fraction", 0.75),
+        min_ratio=config["strandedness_check"].get("min_ratio", 2.0),
+        logdir="logs/{project}/reports/strandedness/",
+    shell:
+        """
+        mkdir -p {params.logdir}
+        python3 workflow/scripts/check_strandedness.py \
+            --star-counts {input.counts} \
+            --output {output} \
+            --sample {params.sample} \
+            --quantification-tool {params.quantification_tool} \
+            --star-strandedness {params.star_strandedness} \
+            --featurecounts-strandedness {params.featurecounts_strandedness} \
+            --mode {params.mode} \
+            --min-fraction {params.min_fraction} \
+            --min-ratio {params.min_ratio} 2> {log}
+        """
+
+
+rule strandedness_check_single:
+    input:
+        counts=rules.star_reads_per_gene_single.output.counts,
+    output:
+        "results/{project}/reports/strandedness_single/{subsample}.strandedness.tsv",
+    log:
+        "logs/{project}/reports/strandedness/{subsample}.log",
+    conda:
+        "../envs/metrics.yml"
+    resources:
+        mem_mb=config["multiqc"]["mem"],
+    params:
+        sample="{subsample}",
+        quantification_tool=config["quantification_tool"],
+        star_strandedness=config["star"].get(
+            "gene_counts_strandedness", "unstranded"
+        ),
+        featurecounts_strandedness=config["featurecounts"].get("strandedness", 0),
+        mode=config["strandedness_check"].get("mode", "warn"),
+        min_fraction=config["strandedness_check"].get("min_fraction", 0.75),
+        min_ratio=config["strandedness_check"].get("min_ratio", 2.0),
+        logdir="logs/{project}/reports/strandedness/",
+    shell:
+        """
+        mkdir -p {params.logdir}
+        python3 workflow/scripts/check_strandedness.py \
+            --star-counts {input.counts} \
+            --output {output} \
+            --sample {params.sample} \
+            --quantification-tool {params.quantification_tool} \
+            --star-strandedness {params.star_strandedness} \
+            --featurecounts-strandedness {params.featurecounts_strandedness} \
+            --mode {params.mode} \
+            --min-fraction {params.min_fraction} \
+            --min-ratio {params.min_ratio} 2> {log}
+        """
+
+
+rule strandedness_summary:
+    input:
+        lambda wildcards: get_strandedness_reports(wildcards, pep, rules, config),
+    output:
+        "results/{project}/final/qc/{project}_strandedness_summary.tsv",
+    log:
+        "logs/{project}/reports/strandedness/summary.log",
+    conda:
+        "../envs/metrics.yml"
+    resources:
+        mem_mb=config["multiqc"]["mem"],
+    params:
+        logdir="logs/{project}/reports/strandedness/",
+    shell:
+        """
+        mkdir -p {params.logdir}
+        python3 workflow/scripts/merge_strandedness_reports.py --output {output} {input} 2> {log}
         """
 
 

--- a/workflow/rules/metrics.smk
+++ b/workflow/rules/metrics.smk
@@ -148,6 +148,12 @@ def get_multiqc_subsamples(wildcards):
                     project=project, subsample=subsample
                 )
             )
+            if config_flag(config, "run_sortmerna"):
+                metricsLST.append(
+                    rules.sortmerna.output.report.format(
+                        project=project, subsample=subsample
+                    )
+                )
         elif seq_method == "single_end":
             metricsLST.append(
                 rules.fastqc_single.output[0].format(
@@ -164,6 +170,12 @@ def get_multiqc_subsamples(wildcards):
                     project=project, subsample=subsample
                 )
             )
+            if config_flag(config, "run_sortmerna"):
+                metricsLST.append(
+                    rules.sortmerna_single.output.report.format(
+                        project=project, subsample=subsample
+                    )
+                )
         if config["quantification_tool"].lower() == "kallisto":
             metricsLST.append(rules.merge_kallisto.output[0].format(project=project))
         elif config["quantification_tool"].lower() == "star":

--- a/workflow/rules/metrics.smk
+++ b/workflow/rules/metrics.smk
@@ -33,7 +33,10 @@ def get_qc_fastqc(wildcards):
         seq_method = get_seq_method(subsample, pep)
         if seq_method == "paired_end":
             out.append(
-                rules.fastqc.output[0].format(project=project, subsample=subsample)
+                rules.fastqc.output.r1.format(project=project, subsample=subsample)
+            )
+            out.append(
+                rules.fastqc.output.r2.format(project=project, subsample=subsample)
             )
             out.append(
                 rules.fastqc_trimmed.output.r1.format(
@@ -68,7 +71,12 @@ def get_qc_fastq_screen(wildcards):
         seq_method = get_seq_method(subsample, pep)
         if seq_method == "paired_end":
             out.append(
-                rules.fastq_screen.output[0].format(
+                rules.fastq_screen.output.r1.format(
+                    project=project, subsample=subsample
+                )
+            )
+            out.append(
+                rules.fastq_screen.output.r2.format(
                     project=project, subsample=subsample
                 )
             )
@@ -115,7 +123,10 @@ def get_multiqc_subsamples(wildcards):
         # Always run rules on the outside
         if seq_method == "paired_end":
             metricsLST.append(
-                rules.fastqc.output[0].format(project=project, subsample=subsample)
+                rules.fastqc.output.r1.format(project=project, subsample=subsample)
+            )
+            metricsLST.append(
+                rules.fastqc.output.r2.format(project=project, subsample=subsample)
             )
             metricsLST.append(
                 rules.fastqc_trimmed.output.r1.format(
@@ -128,7 +139,12 @@ def get_multiqc_subsamples(wildcards):
                 )
             )
             metricsLST.append(
-                rules.fastq_screen.output[0].format(
+                rules.fastq_screen.output.r1.format(
+                    project=project, subsample=subsample
+                )
+            )
+            metricsLST.append(
+                rules.fastq_screen.output.r2.format(
                     project=project, subsample=subsample
                 )
             )
@@ -284,7 +300,8 @@ rule fastq_screen:
         read1=rules.symlink_files.output[0],
         read2=rules.symlink_files.output[1],
     output:
-        "results/{project}/reports/fastq_screen/{subsample}/{subsample}_R1_screen.html",
+        r1="results/{project}/reports/fastq_screen/{subsample}/{subsample}_R1_screen.html",
+        r2="results/{project}/reports/fastq_screen/{subsample}/{subsample}_R2_screen.html",
     log:
         "logs/{project}/reports/fastq_screen/{subsample}.log",
     conda:
@@ -339,7 +356,8 @@ rule fastqc:
         read1=rules.symlink_files.output[0],
         read2=rules.symlink_files.output[1],
     output:
-        "results/{project}/reports/fastqc/{subsample}_R1_fastqc.zip",
+        r1="results/{project}/reports/fastqc/{subsample}_R1_fastqc.zip",
+        r2="results/{project}/reports/fastqc/{subsample}_R2_fastqc.zip",
     log:
         "logs/{project}/reports/fastqc/{subsample}.log",
     conda:

--- a/workflow/rules/quantification.smk
+++ b/workflow/rules/quantification.smk
@@ -11,7 +11,8 @@ rule kallisto:
         transcriptome=rules.gffread.output,
         index=rules.kallisto_index.output,
     output:
-        "results/{project}/quantification/kallisto/{subsample}/abundance.h5",
+        h5="results/{project}/quantification/kallisto/{subsample}/abundance.h5",
+        tsv="results/{project}/quantification/kallisto/{subsample}/abundance.tsv",
     log:
         "logs/{project}/quantification/kallisto/{subsample}.log",
     conda:
@@ -34,7 +35,8 @@ rule kallisto_single:
         transcriptome=rules.gffread.output,
         index=rules.kallisto_index.output,
     output:
-        "results/{project}/quantification/kallisto_single/{subsample}/abundance.h5",
+        h5="results/{project}/quantification/kallisto_single/{subsample}/abundance.h5",
+        tsv="results/{project}/quantification/kallisto_single/{subsample}/abundance.tsv",
     log:
         "logs/{project}/quantification/kallisto_single/{subsample}.log",
     conda:
@@ -56,7 +58,7 @@ rule kallisto_single:
 
 rule merge_kallisto:
     input:
-        lambda wildcards: get_kallisto_h5(wildcards, pep, rules),
+        lambda wildcards: get_kallisto_abundance_tsv(wildcards, pep, rules),
     output:
         tpm="results/{project}/final/quantification/kallisto/transcript_tpms_all_samples.tsv",
         counts="results/{project}/final/quantification/kallisto/transcript_counts_all_samples.tsv",

--- a/workflow/rules/quantification.smk
+++ b/workflow/rules/quantification.smk
@@ -7,7 +7,7 @@
 # Official documentation can be found here: https:/pachterlab.github.io/kallisto/
 rule kallisto:
     input:
-        reads=rules.trim_galore.output,
+        reads=lambda wildcards: get_quantification_reads(wildcards, rules, config),
         transcriptome=rules.gffread.output,
         index=rules.kallisto_index.output,
     output:
@@ -31,7 +31,9 @@ rule kallisto:
 
 rule kallisto_single:
     input:
-        reads=rules.trim_galore_single.output,
+        reads=lambda wildcards: get_quantification_reads_single(
+            wildcards, rules, config
+        ),
         transcriptome=rules.gffread.output,
         index=rules.kallisto_index.output,
     output:
@@ -82,7 +84,7 @@ rule merge_kallisto:
 
 rule star_reads_per_gene:
     input:
-        reads=rules.trim_galore.output,
+        reads=lambda wildcards: get_quantification_reads(wildcards, rules, config),
         transcriptome=rules.gffread.output,
         index=rules.star_index.output,
     output:
@@ -118,7 +120,9 @@ rule star_reads_per_gene:
 
 rule star_reads_per_gene_single:
     input:
-        reads=rules.trim_galore_single.output,
+        reads=lambda wildcards: get_quantification_reads_single(
+            wildcards, rules, config
+        ),
         transcriptome=rules.gffread.output,
         index=rules.star_index.output,
     output:
@@ -155,7 +159,7 @@ rule star_reads_per_gene_single:
 
 rule star_reads_per_transcript:
     input:
-        reads=rules.trim_galore.output,
+        reads=lambda wildcards: get_quantification_reads(wildcards, rules, config),
         transcriptome=rules.gffread.output,
         index=rules.star_index.output,
     output:
@@ -190,7 +194,9 @@ rule star_reads_per_transcript:
 
 rule star_reads_per_transcript_single:
     input:
-        reads=rules.trim_galore_single.output,
+        reads=lambda wildcards: get_quantification_reads_single(
+            wildcards, rules, config
+        ),
         transcriptome=rules.gffread.output,
         index=rules.star_index.output,
     output:

--- a/workflow/rules/resources.smk
+++ b/workflow/rules/resources.smk
@@ -27,7 +27,7 @@ rule download_fastq_screen_genomes:
 
 # Download given genome if needed
 rule download_genome:
-    output: "resources/download_genome/"
+    output: f"resources/download_genome/{config['genome']['name']}.fa"
     params:
         url=config["genome"]["url"]
     log: "logs/resources/download_genome.log"
@@ -39,7 +39,7 @@ rule download_genome:
 
 # Download given gff3 if needed
 rule download_gff3:
-    output: "resources/download_gff3/"
+    output: f"resources/download_gff3/{config['genome']['name']}.gff3"
     params:
         url=config["gff3"]["url"]
     log: "logs/resources/download_gff3.log"
@@ -86,8 +86,7 @@ rule kallisto_index:
     conda: "../envs/quantification.yml"
     shell:
         """
-        kallisto index -i {params.name}.kallisto.index {input} -h > {log} 2>&1
-        mv {params.name}.kallisto.index resources/{params.name} >> {log} 2>&1
+        kallisto index -i {output} {input} > {log} 2>&1
         """
 
 rule convert_gff_to_gtf:

--- a/workflow/rules/trimming.smk
+++ b/workflow/rules/trimming.smk
@@ -28,3 +28,73 @@ rule trim_galore_single:
     resources: mem_mb=config["trim_galore"]["mem"]
     conda: "../envs/trimming.yml"
     shell: "trim_galore {input.read1} -o {params.outdir} 2> {log}"
+
+
+rule sortmerna:
+    input:
+        read1=rules.trim_galore.output.r1,
+        read2=rules.trim_galore.output.r2,
+    output:
+        r1="results/{project}/trimming/sortmerna_paired/{subsample}_R1.non_rRNA.fastq.gz",
+        r2="results/{project}/trimming/sortmerna_paired/{subsample}_R2.non_rRNA.fastq.gz",
+        report="results/{project}/reports/sortmerna_paired/{subsample}.sortmerna.log",
+    log:
+        "logs/{project}/trimming/sortmerna/{subsample}.log"
+    conda:
+        "../envs/trimming.yml"
+    threads: config["sortmerna"]["threads"]
+    resources:
+        mem_mb=config["sortmerna"]["mem"],
+    params:
+        refs=lambda wildcards: " ".join(
+            f"--ref {ref}" for ref in as_list(config["sortmerna"]["refs"])
+        ),
+        workdir="results/{project}/trimming/sortmerna_paired/{subsample}.work/",
+        outdir="results/{project}/trimming/sortmerna_paired/",
+        reportdir="results/{project}/reports/sortmerna_paired/",
+        extra=config["sortmerna"].get("extra", ""),
+    shell:
+        """
+        rm -rf {params.workdir}
+        mkdir -p {params.workdir} {params.outdir} {params.reportdir}
+        sortmerna {params.refs} --reads {input.read1} --reads {input.read2} \
+            --threads {threads} --workdir {params.workdir} --aligned rRNA_reads \
+            --fastx --other non_rRNA_reads --paired_in --out2 {params.extra} \
+            > {log} 2>&1
+        mv {params.workdir}/non_rRNA_reads_fwd.f*q.gz {output.r1}
+        mv {params.workdir}/non_rRNA_reads_rev.f*q.gz {output.r2}
+        mv {params.workdir}/rRNA_reads.log {output.report}
+        """
+
+
+rule sortmerna_single:
+    input:
+        read1=rules.trim_galore_single.output,
+    output:
+        reads="results/{project}/trimming/sortmerna_single/{subsample}.non_rRNA.fastq.gz",
+        report="results/{project}/reports/sortmerna_single/{subsample}.sortmerna.log",
+    log:
+        "logs/{project}/trimming/sortmerna/{subsample}.log"
+    conda:
+        "../envs/trimming.yml"
+    threads: config["sortmerna"]["threads"]
+    resources:
+        mem_mb=config["sortmerna"]["mem"],
+    params:
+        refs=lambda wildcards: " ".join(
+            f"--ref {ref}" for ref in as_list(config["sortmerna"]["refs"])
+        ),
+        workdir="results/{project}/trimming/sortmerna_single/{subsample}.work/",
+        outdir="results/{project}/trimming/sortmerna_single/",
+        reportdir="results/{project}/reports/sortmerna_single/",
+        extra=config["sortmerna"].get("extra", ""),
+    shell:
+        """
+        rm -rf {params.workdir}
+        mkdir -p {params.workdir} {params.outdir} {params.reportdir}
+        sortmerna {params.refs} --reads {input.read1} --threads {threads} \
+            --workdir {params.workdir} --aligned rRNA_reads --fastx \
+            --other non_rRNA_reads {params.extra} > {log} 2>&1
+        mv {params.workdir}/non_rRNA_reads.f*q.gz {output.reads}
+        mv {params.workdir}/rRNA_reads.log {output.report}
+        """

--- a/workflow/scripts/check_strandedness.py
+++ b/workflow/scripts/check_strandedness.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+
+SKIP_ROWS = {
+    "N_unmapped",
+    "N_multimapping",
+    "N_noFeature",
+    "N_ambiguous",
+}
+
+
+def configured_strandedness(quantification_tool, star_value, featurecounts_value):
+    if quantification_tool == "featurecounts":
+        value = str(featurecounts_value)
+        return {"0": "unstranded", "1": "forward", "2": "reverse"}.get(
+            value, value
+        )
+    return str(star_value).lower().replace("-", "_")
+
+
+def infer_star_strandedness(path, min_fraction, min_ratio):
+    unstranded = 0
+    forward = 0
+    reverse = 0
+
+    with open(path) as handle:
+        for line in handle:
+            fields = line.rstrip("\n").split("\t")
+            if len(fields) < 4 or fields[0] in SKIP_ROWS:
+                continue
+            unstranded += int(fields[1])
+            forward += int(fields[2])
+            reverse += int(fields[3])
+
+    stranded_total = forward + reverse
+    if stranded_total == 0:
+        return "unknown", unstranded, forward, reverse, 0.0, 0.0
+
+    dominant = max(forward, reverse)
+    minor = min(forward, reverse)
+    fraction = dominant / stranded_total
+    ratio = float("inf") if minor == 0 else dominant / minor
+
+    if fraction >= min_fraction and ratio >= min_ratio:
+        inferred = "forward" if forward > reverse else "reverse"
+    else:
+        inferred = "unstranded"
+
+    return inferred, unstranded, forward, reverse, fraction, ratio
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Infer library strandedness from STAR ReadsPerGene output."
+    )
+    parser.add_argument("--star-counts", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--sample", required=True)
+    parser.add_argument("--quantification-tool", required=True)
+    parser.add_argument("--star-strandedness", required=True)
+    parser.add_argument("--featurecounts-strandedness", required=True)
+    parser.add_argument("--mode", choices=["warn", "fail"], default="warn")
+    parser.add_argument("--min-fraction", type=float, default=0.75)
+    parser.add_argument("--min-ratio", type=float, default=2.0)
+    args = parser.parse_args()
+
+    quantification_tool = args.quantification_tool.lower()
+    expected = configured_strandedness(
+        quantification_tool,
+        args.star_strandedness,
+        args.featurecounts_strandedness,
+    )
+    inferred, unstranded, forward, reverse, fraction, ratio = infer_star_strandedness(
+        args.star_counts,
+        args.min_fraction,
+        args.min_ratio,
+    )
+
+    status = "pass"
+    message = ""
+    if inferred != "unknown" and expected != inferred:
+        status = "mismatch"
+        message = (
+            f"Configured strandedness is '{expected}', but STAR gene counts "
+            f"suggest '{inferred}' for sample '{args.sample}'."
+        )
+    elif inferred == "unknown":
+        status = "unknown"
+        message = f"Unable to infer strandedness for sample '{args.sample}'."
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with open(output, "w", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "sample",
+                "configured_strandedness",
+                "inferred_strandedness",
+                "status",
+                "star_unstranded_counts",
+                "star_forward_counts",
+                "star_reverse_counts",
+                "dominant_strand_fraction",
+                "dominant_to_minor_ratio",
+                "message",
+            ],
+            delimiter="\t",
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "sample": args.sample,
+                "configured_strandedness": expected,
+                "inferred_strandedness": inferred,
+                "status": status,
+                "star_unstranded_counts": unstranded,
+                "star_forward_counts": forward,
+                "star_reverse_counts": reverse,
+                "dominant_strand_fraction": f"{fraction:.4f}",
+                "dominant_to_minor_ratio": (
+                    "inf" if ratio == float("inf") else f"{ratio:.4f}"
+                ),
+                "message": message,
+            }
+        )
+
+    if status == "mismatch":
+        print(message, file=sys.stderr)
+        if args.mode == "fail":
+            return 1
+    if status == "unknown":
+        print(message, file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/workflow/scripts/merge_strandedness_reports.py
+++ b/workflow/scripts/merge_strandedness_reports.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Merge per-sample strandedness check reports."
+    )
+    parser.add_argument("--output", required=True)
+    parser.add_argument("reports", nargs="+")
+    args = parser.parse_args()
+
+    header_written = False
+    with open(args.output, "w", newline="") as output_handle:
+        writer = None
+        for report in args.reports:
+            with open(report, newline="") as input_handle:
+                reader = csv.DictReader(input_handle, delimiter="\t")
+                if writer is None:
+                    writer = csv.DictWriter(
+                        output_handle,
+                        fieldnames=reader.fieldnames,
+                        delimiter="\t",
+                    )
+                if not header_written:
+                    writer.writeheader()
+                    header_written = True
+                for row in reader:
+                    writer.writerow(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/workflow/scripts/utils.py
+++ b/workflow/scripts/utils.py
@@ -104,6 +104,41 @@ def validate_preflight_inputs(pep, config):
     if transform_method not in {"vst", "rlog", "auto"}:
         errors.append("deseq2.transform_method must be one of: vst, rlog, auto.")
 
+    strandedness_check = config.get("strandedness_check", {})
+    strandedness_check_mode = str(strandedness_check.get("mode", "warn")).lower()
+    if strandedness_check_mode not in {"warn", "fail"}:
+        errors.append("strandedness_check.mode must be one of: warn, fail.")
+    try:
+        strandedness_min_fraction = float(
+            strandedness_check.get("min_fraction", 0.75)
+        )
+    except (TypeError, ValueError):
+        strandedness_min_fraction = 0.75
+        errors.append("strandedness_check.min_fraction must be numeric.")
+    if not 0 <= strandedness_min_fraction <= 1:
+        errors.append("strandedness_check.min_fraction must be between 0 and 1.")
+    try:
+        strandedness_min_ratio = float(strandedness_check.get("min_ratio", 2.0))
+    except (TypeError, ValueError):
+        strandedness_min_ratio = 2.0
+        errors.append("strandedness_check.min_ratio must be numeric.")
+    if strandedness_min_ratio < 1:
+        errors.append("strandedness_check.min_ratio must be at least 1.")
+
+    star_strandedness = str(
+        config.get("star", {}).get("gene_counts_strandedness", "unstranded")
+    ).lower()
+    if star_strandedness not in {"unstranded", "forward", "reverse"}:
+        errors.append(
+            "star.gene_counts_strandedness must be one of: unstranded, "
+            "forward, reverse."
+        )
+    featurecounts_strandedness = config.get("featurecounts", {}).get(
+        "strandedness", 0
+    )
+    if str(featurecounts_strandedness) not in {"0", "1", "2"}:
+        errors.append("featurecounts.strandedness must be one of: 0, 1, 2.")
+
     if config_flag(config, "run_sortmerna"):
         sortmerna_refs = _as_list(config.get("sortmerna", {}).get("refs", []))
         if not sortmerna_refs:
@@ -368,6 +403,32 @@ def get_star_gene_counts(wildcards, pep, rules):
             out.append(rules.star_reads_per_gene.output[0].format(project=project, subsample=subsample))
         elif seq_method == "single_end":
             out.append(rules.star_reads_per_gene_single.output[0].format(project=project, subsample=subsample))
+    return out
+
+
+def get_strandedness_reports(wildcards, pep, rules, config):
+    out = []
+    if not config_flag(config.get("strandedness_check", {}), "enabled", "true"):
+        return out
+    if config["quantification_tool"].lower() not in ["star", "featurecounts"]:
+        return out
+    for subsample in pep.subsample_table.subsample.tolist():
+        project = get_subsample_attributes(subsample, "project", pep)
+        if project != wildcards.project:
+            continue
+        seq_method = get_seq_method(subsample, pep)
+        if seq_method == "paired_end":
+            out.append(
+                rules.strandedness_check.output[0].format(
+                    project=project, subsample=subsample
+                )
+            )
+        elif seq_method == "single_end":
+            out.append(
+                rules.strandedness_check_single.output[0].format(
+                    project=project, subsample=subsample
+                )
+            )
     return out
 
 

--- a/workflow/scripts/utils.py
+++ b/workflow/scripts/utils.py
@@ -12,6 +12,14 @@ def _as_list(value):
     return [value]
 
 
+def as_list(value):
+    return _as_list(value)
+
+
+def config_flag(config, key, default="false"):
+    return str(config.get(key, default)).lower() == "true"
+
+
 def _format_list(values):
     return ", ".join(str(value) for value in sorted(values))
 
@@ -95,6 +103,23 @@ def validate_preflight_inputs(pep, config):
     transform_method = str(deseq_config.get("transform_method", "vst")).lower()
     if transform_method not in {"vst", "rlog", "auto"}:
         errors.append("deseq2.transform_method must be one of: vst, rlog, auto.")
+
+    if config_flag(config, "run_sortmerna"):
+        sortmerna_refs = _as_list(config.get("sortmerna", {}).get("refs", []))
+        if not sortmerna_refs:
+            errors.append(
+                "run_sortmerna is true, but sortmerna.refs does not list any "
+                "local rRNA reference FASTA files."
+            )
+        missing_sortmerna_refs = [
+            ref for ref in sortmerna_refs if not Path(ref).exists()
+        ]
+        if missing_sortmerna_refs:
+            errors.append(
+                "SortMeRNA rRNA reference FASTA paths do not exist: "
+                f"{_format_list(missing_sortmerna_refs)}"
+            )
+
     if not design_formula and variable_to_analyze:
         design_formula = f"~ {variable_to_analyze}"
     if not design_formula:
@@ -286,6 +311,36 @@ def get_kallisto_h5(wildcards, pep, rules):
         elif seq_method == "single_end":
             out.append(rules.kallisto_single.output.h5.format(project=project, subsample=subsample))
     return out
+
+
+def get_quantification_reads(wildcards, rules, config):
+    if config_flag(config, "run_sortmerna"):
+        return [
+            rules.sortmerna.output.r1.format(
+                project=wildcards.project, subsample=wildcards.subsample
+            ),
+            rules.sortmerna.output.r2.format(
+                project=wildcards.project, subsample=wildcards.subsample
+            ),
+        ]
+    return [
+        rules.trim_galore.output.r1.format(
+            project=wildcards.project, subsample=wildcards.subsample
+        ),
+        rules.trim_galore.output.r2.format(
+            project=wildcards.project, subsample=wildcards.subsample
+        ),
+    ]
+
+
+def get_quantification_reads_single(wildcards, rules, config):
+    if config_flag(config, "run_sortmerna"):
+        return rules.sortmerna_single.output.reads.format(
+            project=wildcards.project, subsample=wildcards.subsample
+        )
+    return rules.trim_galore_single.output[0].format(
+        project=wildcards.project, subsample=wildcards.subsample
+    )
 
 
 def get_kallisto_abundance_tsv(wildcards, pep, rules):

--- a/workflow/scripts/utils.py
+++ b/workflow/scripts/utils.py
@@ -282,9 +282,23 @@ def get_kallisto_h5(wildcards, pep, rules):
             continue
         seq_method = get_seq_method(subsample, pep)
         if seq_method == "paired_end":
-            out.append(rules.kallisto.output[0].format(project=project, subsample=subsample))
+            out.append(rules.kallisto.output.h5.format(project=project, subsample=subsample))
         elif seq_method == "single_end":
-            out.append(rules.kallisto_single.output[0].format(project=project, subsample=subsample))
+            out.append(rules.kallisto_single.output.h5.format(project=project, subsample=subsample))
+    return out
+
+
+def get_kallisto_abundance_tsv(wildcards, pep, rules):
+    out = []
+    for subsample in pep.subsample_table.subsample.tolist():
+        project = get_subsample_attributes(subsample, "project", pep)
+        if project != wildcards.project:
+            continue
+        seq_method = get_seq_method(subsample, pep)
+        if seq_method == "paired_end":
+            out.append(rules.kallisto.output.tsv.format(project=project, subsample=subsample))
+        elif seq_method == "single_end":
+            out.append(rules.kallisto_single.output.tsv.format(project=project, subsample=subsample))
     return out
 
 


### PR DESCRIPTION
## Bug Fixes
  - Fixed Kallisto index command by removing the bad -h help flag.
  - Fixed remote genome/GFF rules to declare file outputs instead of directory outputs.
  - Declared paired-end FastQC and FastQ Screen R2 outputs and wired QC/MultiQC inputs to track them.
  - Declared Kallisto abundance.tsv outputs and made merge_kallisto depend on those TSVs directly.
  
## Additions
   - Added run_sortmerna flag in config/config.json, defaulting to "false".
  - Added sortmerna config block in config/tools.json for threads, mem, refs, and extra.
  - Added sortmerna=4.3.7 to workflow/envs/trimming.yml.
  - Added paired-end and single-end SortMeRNA rules after Trim Galore.
  - Quantification now uses SortMeRNA non-rRNA FASTQs only when run_sortmerna=true.
  - MultiQC now includes SortMeRNA logs when enabled.
  - Preflight validation now errors early if run_sortmerna=true but no local sortmerna.refs are provided.
  - Add explicit strandedness detection and enforcement that writes a report and warns it conflicts with featurecounts.strandedness / STAR settings.

  
  