### PR TITLE
Add Sample Identity Fingerprint Report

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ For each project, the workflow produces:
 
 - A MultiQC HTML report.
 - A per-sample QC summary table.
+- A sample identity report that fingerprints expression profiles, identifies
+  each sample's nearest expression neighbor, and flags low-similarity or
+  metadata-discordant samples.
 - FastQC reports for raw reads.
 - FastQC reports for trimmed reads.
 - FastQ Screen reports.
@@ -178,6 +181,9 @@ For each project, final outputs are written under `results/{project}/`.
 
 - `final/multiqc/multiqc_report.html`: combined QC report.
 - `final/qc/{project}_sample_qc_summary.tsv`: per-sample QC summary table.
+- `final/qc/{project}_sample_identity_report.tsv`: expression-profile sample
+  identity report with nearest-neighbor correlations, metadata agreement, and
+  review flags.
 - `count_annotation_overlap/{project}_count_annotation_overlap.tsv`: count-matrix ID and
   annotation ID overlap report.
 - `gene_biotype_count_summary/{project}_gene_biotype_count_summary.tsv`: gene biotype and count
@@ -384,6 +390,14 @@ QC and report options:
   `fastq_screen.aligner`
 - `trim_galore.mem`
 - `multiqc.mem`
+- `sample_identity.group_column`: metadata column used to check whether nearest
+  expression neighbors match the expected group.
+- `sample_identity.top_variable_features`: number of variable features used for
+  sample-profile correlations.
+- `sample_identity.min_nearest_correlation`: minimum nearest-neighbor
+  correlation before a sample is flagged for review.
+- `sample_identity.same_group_margin`: correlation margin used to flag samples
+  that are closer to a different group than to their closest same-group sample.
 - `gunc.mem` and `gunc.threads`
 
 DESeq2 options:

--- a/README.md
+++ b/README.md
@@ -118,10 +118,12 @@ For each project, the workflow produces:
 - A MultiQC HTML report.
 - A per-sample QC summary table.
 - A sample identity report that fingerprints expression profiles, identifies
-  each sample's nearest expression neighbor, and flags low-similarity or
+  each sample's nearest expression neighbor, reports whether that nearest
+  neighbor relationship is reciprocal, and flags low-similarity or
   metadata-discordant samples, including possible duplicate libraries.
 - A sample identity similarity matrix with all pairwise expression-profile
   correlations.
+- A compact sample identity table embedded in the final MultiQC report.
 - FastQC reports for raw reads.
 - FastQC reports for trimmed reads.
 - FastQ Screen reports.
@@ -184,10 +186,12 @@ For each project, final outputs are written under `results/{project}/`.
 - `final/multiqc/multiqc_report.html`: combined QC report.
 - `final/qc/{project}_sample_qc_summary.tsv`: per-sample QC summary table.
 - `final/qc/{project}_sample_identity_report.tsv`: expression-profile sample
-  identity report with nearest-neighbor correlations, metadata agreement, and
-  review flags.
+  identity report with nearest-neighbor correlations, reciprocal-neighbor
+  status, metadata agreement, and review flags.
 - `final/qc/{project}_sample_identity_similarity_matrix.tsv`: all pairwise
   sample expression-profile correlations used by the identity report.
+- `final/qc/{project}_sample_identity_mqc.tsv`: MultiQC custom-content table
+  containing the key sample identity status fields.
 - `count_annotation_overlap/{project}_count_annotation_overlap.tsv`: count-matrix ID and
   annotation ID overlap report.
 - `gene_biotype_count_summary/{project}_gene_biotype_count_summary.tsv`: gene biotype and count

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ For each project, the workflow produces:
 - A per-sample QC summary table.
 - A sample identity report that fingerprints expression profiles, identifies
   each sample's nearest expression neighbor, and flags low-similarity or
-  metadata-discordant samples.
+  metadata-discordant samples, including possible duplicate libraries.
 - A sample identity similarity matrix with all pairwise expression-profile
   correlations.
 - FastQC reports for raw reads.
@@ -402,6 +402,10 @@ QC and report options:
   correlation before a sample is flagged for review.
 - `sample_identity.same_group_margin`: correlation margin used to flag samples
   that are closer to a different group than to their closest same-group sample.
+- `sample_identity.duplicate_min_correlation`: minimum pairwise expression
+  correlation for possible duplicate-library calls.
+- `sample_identity.duplicate_max_library_size_difference`: maximum relative
+  assigned-count difference for possible duplicate-library calls.
 - `gunc.mem` and `gunc.threads`
 
 DESeq2 options:

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ For each project, the workflow produces:
 - A sample identity report that fingerprints expression profiles, identifies
   each sample's nearest expression neighbor, and flags low-similarity or
   metadata-discordant samples.
+- A sample identity similarity matrix with all pairwise expression-profile
+  correlations.
 - FastQC reports for raw reads.
 - FastQC reports for trimmed reads.
 - FastQ Screen reports.
@@ -184,6 +186,8 @@ For each project, final outputs are written under `results/{project}/`.
 - `final/qc/{project}_sample_identity_report.tsv`: expression-profile sample
   identity report with nearest-neighbor correlations, metadata agreement, and
   review flags.
+- `final/qc/{project}_sample_identity_similarity_matrix.tsv`: all pairwise
+  sample expression-profile correlations used by the identity report.
 - `count_annotation_overlap/{project}_count_annotation_overlap.tsv`: count-matrix ID and
   annotation ID overlap report.
 - `gene_biotype_count_summary/{project}_gene_biotype_count_summary.tsv`: gene biotype and count

--- a/config/tools.json
+++ b/config/tools.json
@@ -27,6 +27,12 @@
         "min_fraction": 0.75,
         "min_ratio": 2.0
     },
+    "sample_identity": {
+        "group_column": "Time",
+        "top_variable_features": 5000,
+        "min_nearest_correlation": 0.90,
+        "same_group_margin": 0.03
+    },
     "trim_galore": {
         "mem": 1024
     },

--- a/config/tools.json
+++ b/config/tools.json
@@ -31,7 +31,9 @@
         "group_column": "Time",
         "top_variable_features": 5000,
         "min_nearest_correlation": 0.90,
-        "same_group_margin": 0.03
+        "same_group_margin": 0.03,
+        "duplicate_min_correlation": 0.995,
+        "duplicate_max_library_size_difference": 0.05
     },
     "trim_galore": {
         "mem": 1024

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -86,7 +86,7 @@ rule all:
             project=pep.sample_table.project.unique().tolist(),
         ),
         expand(
-            rules.sample_identity_report.output[0],
+            rules.sample_identity_report.output,
             project=pep.sample_table.project.unique().tolist(),
         ),
         (

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -85,6 +85,10 @@ rule all:
             rules.qc_summary.output[0],
             project=pep.sample_table.project.unique().tolist(),
         ),
+        expand(
+            rules.sample_identity_report.output[0],
+            project=pep.sample_table.project.unique().tolist(),
+        ),
         (
             expand(
                 rules.strandedness_summary.output[0],

--- a/workflow/documentation.md
+++ b/workflow/documentation.md
@@ -12,7 +12,7 @@ inside `workflow/`.
   indices, and optional GUNC databases.
 - `rules/trimming.smk`: trims paired-end and single-end reads with Trim Galore.
 - `rules/metrics.smk`: runs FastQC, FastQ Screen, GUNC, strandedness checks,
-  MultiQC, and the final per-sample QC summary.
+  MultiQC, the final per-sample QC summary, and the sample identity report.
 - `rules/quantification.smk`: runs Kallisto, STAR, or FeatureCounts
   quantification and merges per-sample outputs.
 - `rules/deseq.smk`: runs DESeq2 and writes differential-expression tables plus
@@ -33,6 +33,9 @@ inside `workflow/`.
 - `scripts/combine_kallisto.py`: merges Kallisto `abundance.tsv` files from
   paired-end and single-end output directories.
 - `scripts/summarize_qc.py`: builds the final per-sample QC table.
+- `scripts/sample_identity_report.py`: fingerprints expression profiles from
+  the merged count matrix, reports nearest expression neighbors, and flags
+  low-similarity or metadata-discordant samples.
 - `scripts/check_count_annotation_overlap.py`: compares count-matrix
   `target_id` values with configured annotation feature IDs before DESeq2 runs.
 - `scripts/summarize_gene_biotype_counts.py`: summarizes count support by
@@ -47,6 +50,7 @@ inside `workflow/`.
 
 - `results/{project}/final/multiqc/multiqc_report.html`
 - `results/{project}/final/qc/{project}_sample_qc_summary.tsv`
+- `results/{project}/final/qc/{project}_sample_identity_report.tsv`
 - `results/{project}/final/qc/{project}_strandedness_summary.tsv`
 - `results/{project}/count_annotation_overlap/{project}_count_annotation_overlap.tsv`
 - `results/{project}/gene_biotype_count_summary/{project}_gene_biotype_count_summary.tsv`

--- a/workflow/documentation.md
+++ b/workflow/documentation.md
@@ -51,6 +51,7 @@ inside `workflow/`.
 - `results/{project}/final/multiqc/multiqc_report.html`
 - `results/{project}/final/qc/{project}_sample_qc_summary.tsv`
 - `results/{project}/final/qc/{project}_sample_identity_report.tsv`
+- `results/{project}/final/qc/{project}_sample_identity_similarity_matrix.tsv`
 - `results/{project}/final/qc/{project}_strandedness_summary.tsv`
 - `results/{project}/count_annotation_overlap/{project}_count_annotation_overlap.tsv`
 - `results/{project}/gene_biotype_count_summary/{project}_gene_biotype_count_summary.tsv`

--- a/workflow/documentation.md
+++ b/workflow/documentation.md
@@ -35,7 +35,7 @@ inside `workflow/`.
 - `scripts/summarize_qc.py`: builds the final per-sample QC table.
 - `scripts/sample_identity_report.py`: fingerprints expression profiles from
   the merged count matrix, reports nearest expression neighbors, and flags
-  low-similarity or metadata-discordant samples.
+  low-similarity, metadata-discordant, or possible duplicate-library samples.
 - `scripts/check_count_annotation_overlap.py`: compares count-matrix
   `target_id` values with configured annotation feature IDs before DESeq2 runs.
 - `scripts/summarize_gene_biotype_counts.py`: summarizes count support by

--- a/workflow/documentation.md
+++ b/workflow/documentation.md
@@ -36,6 +36,7 @@ inside `workflow/`.
 - `scripts/sample_identity_report.py`: fingerprints expression profiles from
   the merged count matrix, reports nearest expression neighbors, and flags
   low-similarity, metadata-discordant, or possible duplicate-library samples.
+  Also writes the compact custom-content table consumed by MultiQC.
 - `scripts/check_count_annotation_overlap.py`: compares count-matrix
   `target_id` values with configured annotation feature IDs before DESeq2 runs.
 - `scripts/summarize_gene_biotype_counts.py`: summarizes count support by
@@ -52,6 +53,7 @@ inside `workflow/`.
 - `results/{project}/final/qc/{project}_sample_qc_summary.tsv`
 - `results/{project}/final/qc/{project}_sample_identity_report.tsv`
 - `results/{project}/final/qc/{project}_sample_identity_similarity_matrix.tsv`
+- `results/{project}/final/qc/{project}_sample_identity_mqc.tsv`
 - `results/{project}/final/qc/{project}_strandedness_summary.tsv`
 - `results/{project}/count_annotation_overlap/{project}_count_annotation_overlap.tsv`
 - `results/{project}/gene_biotype_count_summary/{project}_gene_biotype_count_summary.tsv`

--- a/workflow/rules/metrics.smk
+++ b/workflow/rules/metrics.smk
@@ -506,6 +506,47 @@ rule qc_summary:
         """
 
 
+rule sample_identity_report:
+    input:
+        metadata=config["metadata"],
+        counts=get_quant_counts,
+    output:
+        "results/{project}/final/qc/{project}_sample_identity_report.tsv",
+    log:
+        "logs/{project}/reports/sample_identity/sample_identity_report.log",
+    conda:
+        "../envs/metrics.yml"
+    resources:
+        mem_mb=config["multiqc"]["mem"],
+    params:
+        group_column=config.get("sample_identity", {}).get(
+            "group_column",
+            config.get("deseq2", {}).get("variable_to_analyze", ""),
+        ),
+        top_variable_features=config.get("sample_identity", {}).get(
+            "top_variable_features", 5000
+        ),
+        min_nearest_correlation=config.get("sample_identity", {}).get(
+            "min_nearest_correlation", 0.90
+        ),
+        same_group_margin=config.get("sample_identity", {}).get(
+            "same_group_margin", 0.03
+        ),
+        logdir="logs/{project}/reports/sample_identity/",
+    shell:
+        """
+        mkdir -p {params.logdir}
+        python3 workflow/scripts/sample_identity_report.py \
+            --metadata {input.metadata} \
+            --counts {input.counts} \
+            --output {output} \
+            --group-column {params.group_column:q} \
+            --top-variable-features {params.top_variable_features} \
+            --min-nearest-correlation {params.min_nearest_correlation} \
+            --same-group-margin {params.same_group_margin} 2> {log}
+        """
+
+
 rule strandedness_check:
     input:
         counts=rules.star_reads_per_gene.output.counts,

--- a/workflow/rules/metrics.smk
+++ b/workflow/rules/metrics.smk
@@ -536,6 +536,12 @@ rule sample_identity_report:
         same_group_margin=config.get("sample_identity", {}).get(
             "same_group_margin", 0.03
         ),
+        duplicate_min_correlation=config.get("sample_identity", {}).get(
+            "duplicate_min_correlation", 0.995
+        ),
+        duplicate_max_library_size_difference=config.get(
+            "sample_identity", {}
+        ).get("duplicate_max_library_size_difference", 0.05),
         logdir="logs/{project}/reports/sample_identity/",
     shell:
         """
@@ -548,7 +554,10 @@ rule sample_identity_report:
             --group-column {params.group_column:q} \
             --top-variable-features {params.top_variable_features} \
             --min-nearest-correlation {params.min_nearest_correlation} \
-            --same-group-margin {params.same_group_margin} 2> {log}
+            --same-group-margin {params.same_group_margin} \
+            --duplicate-min-correlation {params.duplicate_min_correlation} \
+            --duplicate-max-library-size-difference \
+                {params.duplicate_max_library_size_difference} 2> {log}
         """
 
 

--- a/workflow/rules/metrics.smk
+++ b/workflow/rules/metrics.smk
@@ -281,6 +281,11 @@ def get_multiqc_subsamples(wildcards):
                 rules.gunc_plot.output[0].format(project=project, subsample=subsample)
             )
 
+    metricsLST.append(
+        rules.sample_identity_report.output.multiqc_table.format(
+            project=wildcards.project
+        )
+    )
     return metricsLST
 
 
@@ -516,6 +521,7 @@ rule sample_identity_report:
             "results/{project}/final/qc/"
             "{project}_sample_identity_similarity_matrix.tsv"
         ),
+        multiqc_table="results/{project}/final/qc/{project}_sample_identity_mqc.tsv",
     log:
         "logs/{project}/reports/sample_identity/sample_identity_report.log",
     conda:
@@ -551,6 +557,7 @@ rule sample_identity_report:
             --counts {input.counts} \
             --output {output.report} \
             --similarity-matrix {output.similarity_matrix} \
+            --multiqc-table {output.multiqc_table} \
             --group-column {params.group_column:q} \
             --top-variable-features {params.top_variable_features} \
             --min-nearest-correlation {params.min_nearest_correlation} \

--- a/workflow/rules/metrics.smk
+++ b/workflow/rules/metrics.smk
@@ -511,7 +511,11 @@ rule sample_identity_report:
         metadata=config["metadata"],
         counts=get_quant_counts,
     output:
-        "results/{project}/final/qc/{project}_sample_identity_report.tsv",
+        report="results/{project}/final/qc/{project}_sample_identity_report.tsv",
+        similarity_matrix=(
+            "results/{project}/final/qc/"
+            "{project}_sample_identity_similarity_matrix.tsv"
+        ),
     log:
         "logs/{project}/reports/sample_identity/sample_identity_report.log",
     conda:
@@ -539,7 +543,8 @@ rule sample_identity_report:
         python3 workflow/scripts/sample_identity_report.py \
             --metadata {input.metadata} \
             --counts {input.counts} \
-            --output {output} \
+            --output {output.report} \
+            --similarity-matrix {output.similarity_matrix} \
             --group-column {params.group_column:q} \
             --top-variable-features {params.top_variable_features} \
             --min-nearest-correlation {params.min_nearest_correlation} \

--- a/workflow/scripts/sample_identity_report.py
+++ b/workflow/scripts/sample_identity_report.py
@@ -188,6 +188,14 @@ def fmt_corr(value):
     return "" if value is None else f"{value:.4f}"
 
 
+def reciprocal_nearest_neighbor(sample, nearest):
+    nearest_sample, _nearest_corr = nearest.get(sample, ("", None))
+    if not nearest_sample:
+        return False, "", None
+    reciprocal_sample, reciprocal_corr = nearest.get(nearest_sample, ("", None))
+    return reciprocal_sample == sample, reciprocal_sample, reciprocal_corr
+
+
 def write_similarity_matrix(path, ordered_samples, count_samples, correlations):
     output = Path(path)
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -205,6 +213,34 @@ def write_similarity_matrix(path, ordered_samples, count_samples, correlations):
                 else:
                     row.append("")
             writer.writerow(row)
+
+
+def write_multiqc_table(path, rows):
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "sample",
+        "identity_status",
+        "nearest_sample",
+        "nearest_correlation",
+        "reciprocal_nearest_neighbor",
+        "duplicate_library_candidate",
+        "duplicate_candidate_count",
+        "assigned_counts",
+        "message",
+    ]
+    with open(output, "w", newline="") as handle:
+        handle.write("# id: sample_identity_qc\n")
+        handle.write("# section_name: Sample Identity QC\n")
+        handle.write("# plot_type: table\n")
+        handle.write(
+            "# description: Expression-profile nearest-neighbor, reciprocal "
+            "neighbor, and duplicate-library checks.\n"
+        )
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({field: row.get(field, "") for field in fieldnames})
 
 
 def duplicate_library_candidates(
@@ -288,6 +324,7 @@ def main():
     parser.add_argument("--metadata", required=True)
     parser.add_argument("--output", required=True)
     parser.add_argument("--similarity-matrix", required=True)
+    parser.add_argument("--multiqc-table", required=True)
     parser.add_argument("--group-column", default="")
     parser.add_argument("--top-variable-features", type=int, default=5000)
     parser.add_argument("--min-nearest-correlation", type=float, default=0.90)
@@ -337,6 +374,9 @@ def main():
         "features_used",
         "nearest_sample",
         "nearest_correlation",
+        "reciprocal_nearest_neighbor",
+        "nearest_sample_nearest_neighbor",
+        "nearest_sample_nearest_correlation",
         "nearest_shared_metadata_columns",
         "nearest_different_metadata_columns",
         "group_column",
@@ -357,8 +397,14 @@ def main():
     with open(output, "w", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t")
         writer.writeheader()
+        output_rows = []
         for sample in ordered_samples:
             nearest_sample, nearest_corr = nearest.get(sample, ("", None))
+            (
+                reciprocal_neighbor,
+                nearest_sample_nearest_sample,
+                nearest_sample_nearest_corr,
+            ) = reciprocal_nearest_neighbor(sample, nearest)
             same_sample, same_corr = best_group_neighbor(
                 sample, correlations, metadata_by_sample, group_col, same_group=True
             )
@@ -429,50 +475,55 @@ def main():
             duplicate_exact_fingerprint_match = any(
                 candidate["fingerprint_match"] for candidate in duplicate_candidates
             )
-            writer.writerow(
-                {
-                    "sample": sample,
-                    "metadata_present": str(sample in metadata_by_sample).lower(),
-                    "counts_present": str(sample in count_samples).lower(),
-                    "assigned_counts": (
-                        f"{library_total:.6g}" if sample in count_samples else ""
-                    ),
-                    "fingerprint_sha256_16": (
-                        fingerprints[sample]
-                        if sample in count_samples
-                        else ""
-                    ),
-                    "features_used": len(indexes),
-                    "nearest_sample": nearest_sample,
-                    "nearest_correlation": fmt_corr(nearest_corr),
-                    "nearest_shared_metadata_columns": ",".join(shared),
-                    "nearest_different_metadata_columns": ",".join(different),
-                    "group_column": group_col,
-                    "group_value": metadata_by_sample.get(sample, {}).get(group_col, ""),
-                    "nearest_same_group_sample": same_sample,
-                    "nearest_same_group_correlation": fmt_corr(same_corr),
-                    "nearest_different_group_sample": different_sample,
-                    "nearest_different_group_correlation": fmt_corr(different_corr),
-                    "duplicate_library_candidate": str(duplicate_candidate).lower(),
-                    "duplicate_candidate_count": len(duplicate_candidates),
-                    "duplicate_candidate_samples": ";".join(duplicate_sample_details),
-                    "duplicate_max_correlation": (
-                        fmt_corr(duplicate_candidates[0]["correlation"])
-                        if duplicate_candidates
-                        else ""
-                    ),
-                    "duplicate_min_library_size_relative_difference": (
-                        f"{duplicate_min_library_diff:.4f}"
-                        if duplicate_min_library_diff is not None
-                        else ""
-                    ),
-                    "duplicate_exact_fingerprint_match": str(
-                        duplicate_exact_fingerprint_match
-                    ).lower(),
-                    "identity_status": status,
-                    "message": message,
-                }
-            )
+            row = {
+                "sample": sample,
+                "metadata_present": str(sample in metadata_by_sample).lower(),
+                "counts_present": str(sample in count_samples).lower(),
+                "assigned_counts": (
+                    f"{library_total:.6g}" if sample in count_samples else ""
+                ),
+                "fingerprint_sha256_16": (
+                    fingerprints[sample] if sample in count_samples else ""
+                ),
+                "features_used": len(indexes),
+                "nearest_sample": nearest_sample,
+                "nearest_correlation": fmt_corr(nearest_corr),
+                "reciprocal_nearest_neighbor": str(reciprocal_neighbor).lower(),
+                "nearest_sample_nearest_neighbor": nearest_sample_nearest_sample,
+                "nearest_sample_nearest_correlation": fmt_corr(
+                    nearest_sample_nearest_corr
+                ),
+                "nearest_shared_metadata_columns": ",".join(shared),
+                "nearest_different_metadata_columns": ",".join(different),
+                "group_column": group_col,
+                "group_value": metadata_by_sample.get(sample, {}).get(group_col, ""),
+                "nearest_same_group_sample": same_sample,
+                "nearest_same_group_correlation": fmt_corr(same_corr),
+                "nearest_different_group_sample": different_sample,
+                "nearest_different_group_correlation": fmt_corr(different_corr),
+                "duplicate_library_candidate": str(duplicate_candidate).lower(),
+                "duplicate_candidate_count": len(duplicate_candidates),
+                "duplicate_candidate_samples": ";".join(duplicate_sample_details),
+                "duplicate_max_correlation": (
+                    fmt_corr(duplicate_candidates[0]["correlation"])
+                    if duplicate_candidates
+                    else ""
+                ),
+                "duplicate_min_library_size_relative_difference": (
+                    f"{duplicate_min_library_diff:.4f}"
+                    if duplicate_min_library_diff is not None
+                    else ""
+                ),
+                "duplicate_exact_fingerprint_match": str(
+                    duplicate_exact_fingerprint_match
+                ).lower(),
+                "identity_status": status,
+                "message": message,
+            }
+            writer.writerow(row)
+            output_rows.append(row)
+
+    write_multiqc_table(args.multiqc_table, output_rows)
 
 
 if __name__ == "__main__":

--- a/workflow/scripts/sample_identity_report.py
+++ b/workflow/scripts/sample_identity_report.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Summarize sample identity from expression-profile similarity."""
+
+import argparse
+import csv
+import hashlib
+import math
+from pathlib import Path
+
+
+SKIP_COUNT_COLUMNS = {"length"}
+
+
+def read_metadata(path):
+    with open(path, newline="") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+        fieldnames = reader.fieldnames or []
+    if not fieldnames:
+        return [], [], ""
+    sample_col = "sample_name" if "sample_name" in fieldnames else "sample"
+    if sample_col not in fieldnames:
+        sample_col = fieldnames[0]
+    return rows, fieldnames, sample_col
+
+
+def read_count_matrix(path):
+    with open(path, newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        if not reader.fieldnames:
+            return [], [], {}
+        feature_col = reader.fieldnames[0]
+        samples = [
+            col
+            for col in reader.fieldnames[1:]
+            if col and col not in SKIP_COUNT_COLUMNS
+        ]
+        values = {sample: [] for sample in samples}
+        features = []
+        for row in reader:
+            feature = row.get(feature_col, "")
+            if not feature:
+                continue
+            features.append(feature)
+            for sample in samples:
+                try:
+                    value = float(row.get(sample, 0) or 0)
+                except ValueError:
+                    value = 0.0
+                values[sample].append(value)
+    return features, samples, values
+
+
+def variance(values):
+    if len(values) < 2:
+        return 0.0
+    mean = sum(values) / len(values)
+    return sum((value - mean) ** 2 for value in values) / (len(values) - 1)
+
+
+def pearson(left, right):
+    if len(left) != len(right) or len(left) < 2:
+        return None
+    left_mean = sum(left) / len(left)
+    right_mean = sum(right) / len(right)
+    numerator = 0.0
+    left_ss = 0.0
+    right_ss = 0.0
+    for left_value, right_value in zip(left, right):
+        left_delta = left_value - left_mean
+        right_delta = right_value - right_mean
+        numerator += left_delta * right_delta
+        left_ss += left_delta**2
+        right_ss += right_delta**2
+    denominator = math.sqrt(left_ss * right_ss)
+    if denominator == 0:
+        return None
+    return numerator / denominator
+
+
+def select_variable_feature_indexes(features, samples, values, top_n):
+    if not features or not samples:
+        return []
+    log_values = {
+        sample: [math.log2(max(value, 0.0) + 1.0) for value in values[sample]]
+        for sample in samples
+    }
+    ranked = []
+    for idx, feature in enumerate(features):
+        feature_values = [log_values[sample][idx] for sample in samples]
+        ranked.append((variance(feature_values), feature, idx))
+    ranked.sort(key=lambda item: (-item[0], item[1]))
+    selected = [idx for feature_variance, _feature, idx in ranked if feature_variance > 0]
+    if not selected:
+        selected = [idx for _feature_variance, _feature, idx in ranked]
+    if top_n > 0:
+        selected = selected[:top_n]
+    return selected
+
+
+def selected_log_profiles(samples, values, indexes):
+    profiles = {}
+    for sample in samples:
+        profiles[sample] = [
+            math.log2(max(values[sample][idx], 0.0) + 1.0) for idx in indexes
+        ]
+    return profiles
+
+
+def fingerprint(features, values, indexes, sample, top_n=25):
+    ranked = sorted(
+        (
+            (values[sample][idx], features[idx])
+            for idx in indexes
+            if idx < len(values[sample])
+        ),
+        key=lambda item: (-item[0], item[1]),
+    )[:top_n]
+    payload = "|".join(f"{feature}:{value:.6g}" for value, feature in ranked)
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def metadata_differences(sample, other, metadata_by_sample, metadata_cols, sample_col):
+    left = metadata_by_sample.get(sample, {})
+    right = metadata_by_sample.get(other, {})
+    shared = []
+    different = []
+    for col in metadata_cols:
+        if col == sample_col:
+            continue
+        left_value = left.get(col, "")
+        right_value = right.get(col, "")
+        if left_value == "" or right_value == "":
+            continue
+        if left_value == right_value:
+            shared.append(col)
+        else:
+            different.append(col)
+    return shared, different
+
+
+def nearest_neighbors(samples, profiles):
+    correlations = {sample: {} for sample in samples}
+    for i, sample in enumerate(samples):
+        for other in samples[i + 1 :]:
+            corr = pearson(profiles[sample], profiles[other])
+            correlations[sample][other] = corr
+            correlations[other][sample] = corr
+    nearest = {}
+    for sample in samples:
+        valid = [
+            (other, corr)
+            for other, corr in correlations[sample].items()
+            if corr is not None
+        ]
+        valid.sort(key=lambda item: (-item[1], item[0]))
+        nearest[sample] = valid[0] if valid else ("", None)
+    return nearest, correlations
+
+
+def best_group_neighbor(sample, correlations, metadata_by_sample, group_col, same_group):
+    if not group_col:
+        return "", None
+    group = metadata_by_sample.get(sample, {}).get(group_col, "")
+    if not group:
+        return "", None
+    candidates = []
+    for other, corr in correlations.get(sample, {}).items():
+        if corr is None:
+            continue
+        other_group = metadata_by_sample.get(other, {}).get(group_col, "")
+        if not other_group:
+            continue
+        if (other_group == group) == same_group:
+            candidates.append((other, corr))
+    candidates.sort(key=lambda item: (-item[1], item[0]))
+    return candidates[0] if candidates else ("", None)
+
+
+def fmt_corr(value):
+    return "" if value is None else f"{value:.4f}"
+
+
+def identity_status(
+    sample,
+    count_samples,
+    library_total,
+    nearest_corr,
+    same_group_corr,
+    different_group_corr,
+    min_nearest_correlation,
+    same_group_margin,
+):
+    if sample not in count_samples:
+        return "fail", "Sample is present in metadata but missing from count matrix."
+    if library_total <= 0:
+        return "fail", "Sample has zero assigned counts."
+    if nearest_corr is None:
+        return "limited", "No comparable expression neighbor could be calculated."
+    if nearest_corr < min_nearest_correlation:
+        return "review", "Nearest expression neighbor has low correlation."
+    if (
+        same_group_corr is not None
+        and different_group_corr is not None
+        and different_group_corr - same_group_corr >= same_group_margin
+    ):
+        return (
+            "review",
+            "Sample is closer to a different metadata group than to its closest same-group sample.",
+        )
+    return "pass", ""
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build an expression-profile sample identity report."
+    )
+    parser.add_argument("--counts", required=True)
+    parser.add_argument("--metadata", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--group-column", default="")
+    parser.add_argument("--top-variable-features", type=int, default=5000)
+    parser.add_argument("--min-nearest-correlation", type=float, default=0.90)
+    parser.add_argument("--same-group-margin", type=float, default=0.03)
+    args = parser.parse_args()
+
+    metadata_rows, metadata_cols, sample_col = read_metadata(args.metadata)
+    features, count_samples, count_values = read_count_matrix(args.counts)
+    metadata_by_sample = {
+        row.get(sample_col, ""): row
+        for row in metadata_rows
+        if row.get(sample_col, "")
+    }
+
+    group_col = args.group_column if args.group_column in metadata_cols else ""
+    ordered_samples = [row.get(sample_col, "") for row in metadata_rows if row.get(sample_col, "")]
+    ordered_samples.extend(sample for sample in count_samples if sample not in metadata_by_sample)
+
+    indexes = select_variable_feature_indexes(
+        features, count_samples, count_values, args.top_variable_features
+    )
+    profiles = selected_log_profiles(count_samples, count_values, indexes)
+    nearest, correlations = nearest_neighbors(count_samples, profiles)
+    library_totals = {
+        sample: sum(count_values.get(sample, [])) for sample in count_samples
+    }
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "sample",
+        "metadata_present",
+        "counts_present",
+        "assigned_counts",
+        "fingerprint_sha256_16",
+        "features_used",
+        "nearest_sample",
+        "nearest_correlation",
+        "nearest_shared_metadata_columns",
+        "nearest_different_metadata_columns",
+        "group_column",
+        "group_value",
+        "nearest_same_group_sample",
+        "nearest_same_group_correlation",
+        "nearest_different_group_sample",
+        "nearest_different_group_correlation",
+        "identity_status",
+        "message",
+    ]
+    with open(output, "w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        for sample in ordered_samples:
+            nearest_sample, nearest_corr = nearest.get(sample, ("", None))
+            same_sample, same_corr = best_group_neighbor(
+                sample, correlations, metadata_by_sample, group_col, same_group=True
+            )
+            different_sample, different_corr = best_group_neighbor(
+                sample, correlations, metadata_by_sample, group_col, same_group=False
+            )
+            library_total = library_totals.get(sample, 0.0)
+            status, message = identity_status(
+                sample,
+                set(count_samples),
+                library_total,
+                nearest_corr,
+                same_corr,
+                different_corr,
+                args.min_nearest_correlation,
+                args.same_group_margin,
+            )
+            if sample in count_samples and sample not in metadata_by_sample:
+                status = "review"
+                message = "Sample is present in count matrix but missing from metadata."
+            shared, different = metadata_differences(
+                sample, nearest_sample, metadata_by_sample, metadata_cols, sample_col
+            )
+            writer.writerow(
+                {
+                    "sample": sample,
+                    "metadata_present": str(sample in metadata_by_sample).lower(),
+                    "counts_present": str(sample in count_samples).lower(),
+                    "assigned_counts": f"{library_total:.6g}" if sample in count_samples else "",
+                    "fingerprint_sha256_16": (
+                        fingerprint(features, count_values, indexes, sample)
+                        if sample in count_samples
+                        else ""
+                    ),
+                    "features_used": len(indexes),
+                    "nearest_sample": nearest_sample,
+                    "nearest_correlation": fmt_corr(nearest_corr),
+                    "nearest_shared_metadata_columns": ",".join(shared),
+                    "nearest_different_metadata_columns": ",".join(different),
+                    "group_column": group_col,
+                    "group_value": metadata_by_sample.get(sample, {}).get(group_col, ""),
+                    "nearest_same_group_sample": same_sample,
+                    "nearest_same_group_correlation": fmt_corr(same_corr),
+                    "nearest_different_group_sample": different_sample,
+                    "nearest_different_group_correlation": fmt_corr(different_corr),
+                    "identity_status": status,
+                    "message": message,
+                }
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/workflow/scripts/sample_identity_report.py
+++ b/workflow/scripts/sample_identity_report.py
@@ -181,6 +181,25 @@ def fmt_corr(value):
     return "" if value is None else f"{value:.4f}"
 
 
+def write_similarity_matrix(path, ordered_samples, count_samples, correlations):
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    count_sample_set = set(count_samples)
+    with open(output, "w", newline="") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(["sample", *ordered_samples])
+        for sample in ordered_samples:
+            row = [sample]
+            for other in ordered_samples:
+                if sample == other and sample in count_sample_set:
+                    row.append("1.0000")
+                elif sample in count_sample_set and other in count_sample_set:
+                    row.append(fmt_corr(correlations.get(sample, {}).get(other)))
+                else:
+                    row.append("")
+            writer.writerow(row)
+
+
 def identity_status(
     sample,
     count_samples,
@@ -218,6 +237,7 @@ def main():
     parser.add_argument("--counts", required=True)
     parser.add_argument("--metadata", required=True)
     parser.add_argument("--output", required=True)
+    parser.add_argument("--similarity-matrix", required=True)
     parser.add_argument("--group-column", default="")
     parser.add_argument("--top-variable-features", type=int, default=5000)
     parser.add_argument("--min-nearest-correlation", type=float, default=0.90)
@@ -244,6 +264,9 @@ def main():
     library_totals = {
         sample: sum(count_values.get(sample, [])) for sample in count_samples
     }
+    write_similarity_matrix(
+        args.similarity_matrix, ordered_samples, count_samples, correlations
+    )
 
     output = Path(args.output)
     output.parent.mkdir(parents=True, exist_ok=True)

--- a/workflow/scripts/sample_identity_report.py
+++ b/workflow/scripts/sample_identity_report.py
@@ -120,6 +120,13 @@ def fingerprint(features, values, indexes, sample, top_n=25):
     return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
 
+def library_size_relative_difference(left, right):
+    denominator = max(left, right)
+    if denominator <= 0:
+        return None
+    return abs(left - right) / denominator
+
+
 def metadata_differences(sample, other, metadata_by_sample, metadata_cols, sample_col):
     left = metadata_by_sample.get(sample, {})
     right = metadata_by_sample.get(other, {})
@@ -200,6 +207,48 @@ def write_similarity_matrix(path, ordered_samples, count_samples, correlations):
             writer.writerow(row)
 
 
+def duplicate_library_candidates(
+    sample,
+    count_samples,
+    correlations,
+    library_totals,
+    fingerprints,
+    min_correlation,
+    max_library_size_difference,
+):
+    if sample not in count_samples:
+        return []
+    candidates = []
+    for other in count_samples:
+        if other == sample:
+            continue
+        corr = correlations.get(sample, {}).get(other)
+        if corr is None or corr < min_correlation:
+            continue
+        library_diff = library_size_relative_difference(
+            library_totals.get(sample, 0.0), library_totals.get(other, 0.0)
+        )
+        if library_diff is None or library_diff > max_library_size_difference:
+            continue
+        fingerprint_match = fingerprints.get(sample) == fingerprints.get(other)
+        candidates.append(
+            {
+                "sample": other,
+                "correlation": corr,
+                "library_size_relative_difference": library_diff,
+                "fingerprint_match": fingerprint_match,
+            }
+        )
+    candidates.sort(
+        key=lambda item: (
+            -item["correlation"],
+            item["library_size_relative_difference"],
+            item["sample"],
+        )
+    )
+    return candidates
+
+
 def identity_status(
     sample,
     count_samples,
@@ -225,7 +274,8 @@ def identity_status(
     ):
         return (
             "review",
-            "Sample is closer to a different metadata group than to its closest same-group sample.",
+            "Sample is closer to a different metadata group than to its "
+            "closest same-group sample.",
         )
     return "pass", ""
 
@@ -242,6 +292,10 @@ def main():
     parser.add_argument("--top-variable-features", type=int, default=5000)
     parser.add_argument("--min-nearest-correlation", type=float, default=0.90)
     parser.add_argument("--same-group-margin", type=float, default=0.03)
+    parser.add_argument("--duplicate-min-correlation", type=float, default=0.995)
+    parser.add_argument(
+        "--duplicate-max-library-size-difference", type=float, default=0.05
+    )
     args = parser.parse_args()
 
     metadata_rows, metadata_cols, sample_col = read_metadata(args.metadata)
@@ -263,6 +317,10 @@ def main():
     nearest, correlations = nearest_neighbors(count_samples, profiles)
     library_totals = {
         sample: sum(count_values.get(sample, [])) for sample in count_samples
+    }
+    fingerprints = {
+        sample: fingerprint(features, count_values, indexes, sample)
+        for sample in count_samples
     }
     write_similarity_matrix(
         args.similarity_matrix, ordered_samples, count_samples, correlations
@@ -287,6 +345,12 @@ def main():
         "nearest_same_group_correlation",
         "nearest_different_group_sample",
         "nearest_different_group_correlation",
+        "duplicate_library_candidate",
+        "duplicate_candidate_count",
+        "duplicate_candidate_samples",
+        "duplicate_max_correlation",
+        "duplicate_min_library_size_relative_difference",
+        "duplicate_exact_fingerprint_match",
         "identity_status",
         "message",
     ]
@@ -315,17 +379,66 @@ def main():
             if sample in count_samples and sample not in metadata_by_sample:
                 status = "review"
                 message = "Sample is present in count matrix but missing from metadata."
+            duplicate_candidates = duplicate_library_candidates(
+                sample,
+                count_samples,
+                correlations,
+                library_totals,
+                fingerprints,
+                args.duplicate_min_correlation,
+                args.duplicate_max_library_size_difference,
+            )
+            duplicate_candidate = bool(duplicate_candidates)
+            if duplicate_candidate:
+                duplicate_message = (
+                    "Possible duplicate library: expression profile and assigned "
+                    "count total closely match another sample."
+                )
+                if status == "pass":
+                    status = "review"
+                    message = duplicate_message
+                elif message:
+                    message = f"{message} {duplicate_message}"
+                else:
+                    message = duplicate_message
             shared, different = metadata_differences(
                 sample, nearest_sample, metadata_by_sample, metadata_cols, sample_col
+            )
+            duplicate_sample_details = []
+            for candidate in duplicate_candidates:
+                library_diff = candidate["library_size_relative_difference"]
+                duplicate_sample_details.append(
+                    (
+                        "{sample}:r={corr}:library_diff={library_diff}:"
+                        "fingerprint_match={match}"
+                    ).format(
+                        sample=candidate["sample"],
+                        corr=fmt_corr(candidate["correlation"]),
+                        library_diff=f"{library_diff:.4f}",
+                        match=str(candidate["fingerprint_match"]).lower(),
+                    )
+                )
+            duplicate_min_library_diff = (
+                min(
+                    candidate["library_size_relative_difference"]
+                    for candidate in duplicate_candidates
+                )
+                if duplicate_candidates
+                else None
+            )
+            duplicate_exact_fingerprint_match = any(
+                candidate["fingerprint_match"] for candidate in duplicate_candidates
             )
             writer.writerow(
                 {
                     "sample": sample,
                     "metadata_present": str(sample in metadata_by_sample).lower(),
                     "counts_present": str(sample in count_samples).lower(),
-                    "assigned_counts": f"{library_total:.6g}" if sample in count_samples else "",
+                    "assigned_counts": (
+                        f"{library_total:.6g}" if sample in count_samples else ""
+                    ),
                     "fingerprint_sha256_16": (
-                        fingerprint(features, count_values, indexes, sample)
+                        fingerprints[sample]
                         if sample in count_samples
                         else ""
                     ),
@@ -340,6 +453,22 @@ def main():
                     "nearest_same_group_correlation": fmt_corr(same_corr),
                     "nearest_different_group_sample": different_sample,
                     "nearest_different_group_correlation": fmt_corr(different_corr),
+                    "duplicate_library_candidate": str(duplicate_candidate).lower(),
+                    "duplicate_candidate_count": len(duplicate_candidates),
+                    "duplicate_candidate_samples": ";".join(duplicate_sample_details),
+                    "duplicate_max_correlation": (
+                        fmt_corr(duplicate_candidates[0]["correlation"])
+                        if duplicate_candidates
+                        else ""
+                    ),
+                    "duplicate_min_library_size_relative_difference": (
+                        f"{duplicate_min_library_diff:.4f}"
+                        if duplicate_min_library_diff is not None
+                        else ""
+                    ),
+                    "duplicate_exact_fingerprint_match": str(
+                        duplicate_exact_fingerprint_match
+                    ).lower(),
                     "identity_status": status,
                     "message": message,
                 }

--- a/workflow/scripts/utils.py
+++ b/workflow/scripts/utils.py
@@ -165,6 +165,31 @@ def validate_preflight_inputs(pep, config):
         errors.append("sample_identity.same_group_margin must be numeric.")
     if sample_identity_same_group_margin < 0:
         errors.append("sample_identity.same_group_margin must be at least 0.")
+    try:
+        sample_identity_duplicate_min_corr = float(
+            sample_identity.get("duplicate_min_correlation", 0.995)
+        )
+    except (TypeError, ValueError):
+        sample_identity_duplicate_min_corr = 0.995
+        errors.append("sample_identity.duplicate_min_correlation must be numeric.")
+    if not -1 <= sample_identity_duplicate_min_corr <= 1:
+        errors.append(
+            "sample_identity.duplicate_min_correlation must be between -1 and 1."
+        )
+    try:
+        sample_identity_duplicate_max_library_diff = float(
+            sample_identity.get("duplicate_max_library_size_difference", 0.05)
+        )
+    except (TypeError, ValueError):
+        sample_identity_duplicate_max_library_diff = 0.05
+        errors.append(
+            "sample_identity.duplicate_max_library_size_difference must be numeric."
+        )
+    if not 0 <= sample_identity_duplicate_max_library_diff <= 1:
+        errors.append(
+            "sample_identity.duplicate_max_library_size_difference must be "
+            "between 0 and 1."
+        )
 
     star_strandedness = str(
         config.get("star", {}).get("gene_counts_strandedness", "unstranded")

--- a/workflow/scripts/utils.py
+++ b/workflow/scripts/utils.py
@@ -125,6 +125,47 @@ def validate_preflight_inputs(pep, config):
     if strandedness_min_ratio < 1:
         errors.append("strandedness_check.min_ratio must be at least 1.")
 
+    sample_identity = config.get("sample_identity", {})
+    sample_identity_group_column = sample_identity.get("group_column", "")
+    if (
+        sample_identity_group_column
+        and metadata_columns
+        and sample_identity_group_column not in metadata_columns
+    ):
+        errors.append(
+            "sample_identity.group_column is not present in metadata: "
+            f"{sample_identity_group_column}"
+        )
+    try:
+        sample_identity_top_features = int(
+            sample_identity.get("top_variable_features", 5000)
+        )
+    except (TypeError, ValueError):
+        sample_identity_top_features = 5000
+        errors.append("sample_identity.top_variable_features must be an integer.")
+    if sample_identity_top_features < 1:
+        errors.append("sample_identity.top_variable_features must be at least 1.")
+    try:
+        sample_identity_min_corr = float(
+            sample_identity.get("min_nearest_correlation", 0.90)
+        )
+    except (TypeError, ValueError):
+        sample_identity_min_corr = 0.90
+        errors.append("sample_identity.min_nearest_correlation must be numeric.")
+    if not -1 <= sample_identity_min_corr <= 1:
+        errors.append(
+            "sample_identity.min_nearest_correlation must be between -1 and 1."
+        )
+    try:
+        sample_identity_same_group_margin = float(
+            sample_identity.get("same_group_margin", 0.03)
+        )
+    except (TypeError, ValueError):
+        sample_identity_same_group_margin = 0.03
+        errors.append("sample_identity.same_group_margin must be numeric.")
+    if sample_identity_same_group_margin < 0:
+        errors.append("sample_identity.same_group_margin must be at least 0.")
+
     star_strandedness = str(
         config.get("star", {}).get("gene_counts_strandedness", "unstranded")
     ).lower()


### PR DESCRIPTION
**Goal:** To use the final count/TPM matrix to compute a compact expression fingerprint per sample: nearest neighbors, replicate concordance, possible swaps, and metadata mismatches. this helps catch mislabeled samples, duplicated libraries, failed replicates, and condition swaps before any downstream biology.

- Added `results/{project}/final/qc/{project}_sample_identity_similarity_matrix.tsv`, a full pairwise sample correlation matrix used by the identity report.
- Updated rule sample_identity_report to produce both the main identity report and the similarity matrix.
- Updated rule all so Snakemake tracks both sample identity outputs.
- Added duplicate-library detection to the identity report.
- Added duplicate-related output columns, including candidate count, candidate samples, max correlation, library-size relative difference, and exact fingerprint match.
- Added configurable duplicate thresholds:
      - sample_identity.duplicate_min_correlation
      - sample_identity.duplicate_max_library_size_difference
- Added preflight validation for those new config values.
- Updated README and workflow documentation to describe the similarity matrix and duplicate-library detection.
- Added reciprocal nearest-neighbor columns to the sample identity report:
      - reciprocal_nearest_neighbor
      - nearest_sample_nearest_neighbor
      - nearest_sample_nearest_correlation
- Added a compact MultiQC custom-content table: `results/{project}/final/qc/{project}_sample_identity_mqc.tsv`